### PR TITLE
Fix GiBMiB format RAM units due to value being hardcoded in some presets

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+      contents: read
     outputs:
       ffversion: ${{ steps.ffversion.outputs.ffversion }}
     steps:
@@ -57,6 +58,7 @@ jobs:
     runs-on: macos-latest
     permissions:
       security-events: write
+      contents: read
     steps:
       - name: checkout repository
         uses: actions/checkout@v3

--- a/src/util/FFstrbuf.h
+++ b/src/util/FFstrbuf.h
@@ -117,7 +117,9 @@ static inline void ffStrbufAppendS(FFstrbuf* strbuf, const char* value)
 static inline void ffStrbufSetS(FFstrbuf* strbuf, const char* value)
 {
     ffStrbufClear(strbuf);
-    ffStrbufAppendNS(strbuf, (uint32_t) strlen(value), value);
+
+    if(value != NULL)
+        ffStrbufAppendNS(strbuf, (uint32_t) strlen(value), value);
 }
 
 static inline void ffStrbufInitS(FFstrbuf* strbuf, const char* str)


### PR DESCRIPTION
https://forum.garudalinux.org/t/gibmib-shown-for-ram-units-in-konsole-and-alacritty/23117/6?u=sgs